### PR TITLE
Error out if the config file cannot be found

### DIFF
--- a/cmd/awsauthd/awsauthd.go
+++ b/cmd/awsauthd/awsauthd.go
@@ -13,11 +13,13 @@ import (
 
 func main() {
 	listenAddress := flag.String("listen", ":8080", "The address the web server should listen on")
-	configFile := flag.String("config", "", "The path to the configuration file")
+	configFile := flag.String("config", "awsauthd.conf", "The path to the configuration file")
 	flag.Parse()
 
 	config.SetPrefix("AWSAUTHD_")
-	config.Parse(*configFile)
+	if err := config.Parse(*configFile); err != nil {
+		log.Fatal(err)
+	}
 
 	if err := awsconsoleauth.Initialize(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Also provide a reasonable default config file name.
